### PR TITLE
Added filter to prevent label caching

### DIFF
--- a/i18n/i18n.py
+++ b/i18n/i18n.py
@@ -2,6 +2,7 @@ import json
 import os
 import glob
 
+from jinja2 import contextfilter
 
 TRANSLATIONS = {}
 
@@ -31,8 +32,8 @@ def I18n(app):
         print('Error loading localization files.')
         print(e)
 
-
-def trans(symbol):
+@contextfilter
+def trans(context, symbol):
     """Translation filter for templates.
     Fetches the current locale from the request.
 


### PR DESCRIPTION
Problem: sometimes labels do not correctly change when changing locale. They stick to the previous locale for _some time_.

Source of the solution: https://stackoverflow.com/questions/20654274/disable-jinja-template-caching-for-certain-filter